### PR TITLE
Optionally allow one entrypoint to be built

### DIFF
--- a/src/stedi/lambda/build.clj
+++ b/src/stedi/lambda/build.clj
@@ -86,8 +86,10 @@
     (doseq [entrypoint (registry/find-entrypoints paths)]
       (bundle entrypoint))))
 
-(defn -main []
+(defn -main [& [entrypoint]]
   (when-not (get-in (deps) [:deps 'stedi/lambda])
     (throw (Exception. "Could not find stedi/lambda in :deps, did you forget to include it?")))
-  (bundle-all)
+  (if entrypoint
+    (bundle entrypoint)
+    (bundle-all))
   (shutdown-agents))


### PR DESCRIPTION
A single entrypoint be built by providing the entrypoint name.

Example

```
clj -m stedi.lambda.build my.app/handler
```

Fixes #7 