### PR TITLE
Change `:input-stream` to `:input` in request map

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,9 +29,9 @@ Lambda handler so the build tool knows what to compile.
 
   See doc for `stedi.lambda/defentrypoint`"
   [handler]
-  ;; input-stream is a java.io.InputStream
-  (fn [{:keys [input-stream] :as req}]
-    (let [resp (handler (assoc req :payload (slurp input-stream)))]
+  ;; input is a java.io.InputStream
+  (fn [{:keys [input] :as req}]
+    (let [resp (handler (assoc req :input (slurp input)))]
       ;; :output can be a String or anything coercible
       ;; by `clojure.java.io/input-stream`
       {:output (pr-str resp)})))

--- a/example/src/stedi/example.clj
+++ b/example/src/stedi/example.clj
@@ -4,13 +4,13 @@
 (defn wrap-slurp
   "Example middleware to show off middleware pattern with lambdas."
   [handler]
-  (fn [{:keys [input-stream] :as req}]
+  (fn [{:keys [input] :as req}]
     (let [resp (handler (-> req
-                            (assoc :payload (slurp input-stream))))]
+                            (assoc :input (slurp input))))]
       {:output (pr-str resp)})))
 
-(defn hello [{:keys [payload]}]
-  {:my-payload payload})
+(defn hello [{:keys [input]}]
+  {:my-payload input})
 
 (defentrypoint hello-lambda
   (-> hello

--- a/src/stedi/lambda.clj
+++ b/src/stedi/lambda.clj
@@ -8,8 +8,8 @@
 (defn- make-lambda-entrypoint
   [handler-name]
   `(defn ~'-handler [is# os# context#]
-     (let [output# (-> (~handler-name {:input-stream is#
-                                       :context      context#})
+     (let [output# (-> (~handler-name {:input   is#
+                                       :context context#})
                        (:output))
            stream# (io/input-stream
                      (if (string? output#)
@@ -26,8 +26,8 @@
   that takes a lambda request map and returns a lambda response map.
 
   Request Map:
-    :input-stream - an input stream of the payload
-    :context      - an instance of `com.amazonaws.services.lambda.runtime.Context`
+    :input   - an input stream of the payload
+    :context - an instance of `com.amazonaws.services.lambda.runtime.Context`
 
   Response Map:
     :output - a String or anything coercible by `clojure.java.io/input-stream`


### PR DESCRIPTION
The request and response map keys should represent the role of the
data and not the format of the data. `:input` is expected to act like
`:body` in ring, it starts off as an input stream but the included
middleware will transform it into an edn representation maintaining
the same key name.

/cc @dchelimsky since this would break the middleware that he has already started to form.

Fixes #15 