### PR TITLE
Add support for ring handler lambdas behind API Gateway

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -1,5 +1,6 @@
 {:paths   ["src"]
- :deps    {com.amazonaws/aws-lambda-java-core {:mvn/version "1.2.0"}}
+ :deps    {com.amazonaws/aws-lambda-java-core {:mvn/version "1.2.0"}
+           org.clojure/data.json {:mvn/version "0.2.7"}}
  :aliases {:dev  {:extra-paths ["test" "example" "example/target/lambda/stedi.example/hello.jar"]
                   :extra-deps  {com.cognitect/test-runner {:git/url "https://github.com/cognitect-labs/test-runner.git"
                                                            :sha     "cb96e80f6f3d3b307c59cbeb49bb0dcb3a2a780b"}}}

--- a/src/stedi/lambda/apigw.clj
+++ b/src/stedi/lambda/apigw.clj
@@ -1,0 +1,59 @@
+(ns stedi.lambda.apigw
+  "Tools for lambdas that are invoked via API Gateway.
+
+  Contains functions to convert API Gateway events into ring requests, and ring
+  responses into API Gateway responses."
+  ;; NOTE: some of the initial code was copied from here (MIT License):
+  ;;       https://github.com/mhjort/ring-apigw-lambda-proxy
+  (:require [clojure.string :as string]
+            [stedi.lambda.middleware :as middleware])
+  (:import [java.io ByteArrayInputStream]
+           [java.net URLEncoder]))
+
+(defn- generate-query-string [params]
+  (string/join "&" (map (fn [[k v]]
+                          (str (URLEncoder/encode (name k)) "=" (URLEncoder/encode (str v))))
+                        params)))
+
+(defn- request->http-method [request]
+  (-> (:httpMethod request)
+      (string/lower-case)
+      (keyword)))
+
+(defn- keyword->lowercase-string [k]
+  (string/lower-case (name k)))
+
+(defn- map-keys [f m]
+  (into {} (map (fn [[k v]] [(f k) v]) m)))
+
+(defn apigw-request->ring-request [apigw-request]
+  {:pre [(every? #(contains? apigw-request %) [:httpMethod :path :queryStringParameters])
+         (contains? #{"GET" "POST" "OPTIONS" "DELETE" "PUT" "PATCH"} (:httpMethod apigw-request))]}
+  {:uri            (:path apigw-request)
+   :query-string   (generate-query-string (:queryStringParameters apigw-request))
+   :request-method (request->http-method apigw-request)
+   :headers        (map-keys keyword->lowercase-string (:headers apigw-request))
+   :body           (when-let [body (:body apigw-request)]
+                     (ByteArrayInputStream. (.getBytes body "UTF-8")))})
+
+(defn wrap-apigw-lambda-proxy
+  "Middleware wrap a ring handler function. The handler will receive a ring
+  request map built from an API Gateway request. The ring request will contain
+  the following additional keys:
+
+    - :context: com.amazonaws.services.lambda.runtime.Context
+
+  The response should be a standard ring response. It will be converted into an
+  API Gateway response."
+  [ring-handler]
+  (-> (fn [{:keys [input context]}]
+        (let [ring-request   (-> input
+                                 apigw-request->ring-request
+                                 (assoc :context context))
+              ring-response  (ring-handler ring-request)
+              apigw-response {:statusCode (:status ring-response)
+                              :headers    (:headers ring-response)
+                              :body       (:body ring-response)}]
+          {:output apigw-response}))
+      middleware/wrap-json-input
+      middleware/wrap-json-output))

--- a/src/stedi/lambda/middleware.clj
+++ b/src/stedi/lambda/middleware.clj
@@ -1,0 +1,24 @@
+(ns stedi.lambda.middleware
+  "Some useful lambda middlewares."
+  (:require [clojure.data.json :as json]
+            [clojure.java.io :as io]))
+
+(defn wrap-json-input
+  "Parse the input as JSON. Downstream handlers with receive a map where the value
+  of `:input` is a clojure map with keyword keys."
+  [handler]
+  (fn [req]
+    ;; :input of req is a java.io.InputStream
+    (handler (-> req
+                 (update :input io/reader)
+                 (update :input #(json/read % :key-fn keyword))))))
+
+(defn wrap-json-output
+  "Wrap a handler that will return a value that is convertible to JSON. This
+  middleware will write the JSON to the lambda's response stream."
+  [handler]
+  ;; :output can be a String or anything coercible
+  ;; by `clojure.java.io/input-stream`
+  (fn [req]
+    (-> (handler req)
+        (update :output json/write-str))))

--- a/test/stedi/lambda_test.clj
+++ b/test/stedi/lambda_test.clj
@@ -1,0 +1,29 @@
+(ns stedi.lambda-test
+  (:require [clojure.data.json :as json]
+            [clojure.java.io :as io]
+            [clojure.test :refer [deftest is]]
+            [stedi.lambda :as lambda :refer [defentrypoint]]
+            [stedi.lambda.apigw :as apigw])
+  (:import com.amazonaws.services.lambda.runtime.Context
+           java.io.ByteArrayOutputStream))
+
+(defn my-ring-handler [request]
+  {:status  200
+   :headers {"x-whatever" "abc123"}
+   :body    (json/write-str {:id 123 :value "stuff"})})
+
+(defentrypoint ring-handler
+  (-> my-ring-handler
+      apigw/wrap-apigw-lambda-proxy))
+
+(deftest test-ring-lambda
+  (let [apigw-request {:httpMethod            "GET"
+                       :path                  "/foo/bar"
+                       :queryStringParameters {:x 42 :y "blah"}}
+        istream       (io/input-stream (.getBytes (json/write-str apigw-request)))
+        context       nil
+        response      (ring-handler {:input istream :context context})]
+    (let [response (json/read-str (:output response) :key-fn keyword)
+          body     (json/read-str (:body response) :key-fn keyword)]
+      (is (= "stuff" (:value body)))
+      (is (= 123 (:id body))))))


### PR DESCRIPTION
Adds a middleware that wraps a ring handler function so it can be deployed as a lambda behind API Gateway.

eg:

```clojure
(ns my.ring.app
  (:require [stedi.lambda :refer [defentrypoint]]
            [stedi.lambda.apigw :as apigw]))

(defn my-ring-handler [request]
  {:status 200 :body "Hello from lambda"})

(defentrypoint ring-handler
  (-> my-ring-handler
      apigw/wrap-apigw-lambda-proxy))
```